### PR TITLE
Use latest foxglove channel

### DIFF
--- a/setup-robcos-device.sh
+++ b/setup-robcos-device.sh
@@ -23,7 +23,7 @@ echo "Installed cos-registration agent snap"
 snap install ros2-exporter-agent --channel=latest/beta
 echo "Installed ros2-exporter-agent snap"
 
-snap install foxglove-bridge --channel=jazzy/beta
+snap install foxglove-bridge --channel=cos-humble/candidate
 echo "Installed foxglove-bridge snap"
 
 snap install rob-cos-grafana-agent --channel=core24/edge

--- a/setup-robcos-device.sh
+++ b/setup-robcos-device.sh
@@ -23,7 +23,7 @@ echo "Installed cos-registration agent snap"
 snap install ros2-exporter-agent --channel=latest/beta
 echo "Installed ros2-exporter-agent snap"
 
-snap install foxglove-bridge --channel=cos-humble/candidate
+snap install foxglove-bridge --channel=cos-jazzy/stable
 echo "Installed foxglove-bridge snap"
 
 snap install rob-cos-grafana-agent --channel=core24/edge


### PR DESCRIPTION
This PR makes sure we use the latest foxglove channel. The channel only adds a content sharing with data sharing, which is then used when enabling TLS certificates.
This is not strictly needed in the basic setup, however if a user wants to try switching their setup to TLS they can just connect the snap instead of refreshing and doing extra steps.