### PR TITLE
[hermes-agent] fix: use ros2-exporter-agent latest/candidate in setup script

### DIFF
--- a/setup-robcos-device.sh
+++ b/setup-robcos-device.sh
@@ -20,13 +20,13 @@ echo "Installed rob-cos-data sharing snap"
 snap install cos-registration-agent --channel=latest/beta
 echo "Installed cos-registration agent snap"
 
-snap install ros2-exporter-agent --channel=latest/edge
+snap install ros2-exporter-agent --channel=latest/candidate
 echo "Installed ros2-exporter-agent snap"
 
 snap install foxglove-bridge --channel=cos-jazzy/stable
 echo "Installed foxglove-bridge snap"
 
-snap install rob-cos-grafana-agent --channel=core24/edge
+snap install rob-cos-grafana-agent --channel=core24/candidate
 # Connecting all the interfaces to read logs which are not autoconnect
 snap connect rob-cos-grafana-agent:hardware-observe
 snap connect rob-cos-grafana-agent:log-observe


### PR DESCRIPTION
[hermes-agent]

## Overview

This PR follows the intent of [canonical/rob-cos-device-setup#15](https://github.com/canonical/rob-cos-device-setup/pull/15) but targets the standard candidate channels, so it is ready to work once [canonical/ros2-exporter-agent#35](https://github.com/canonical/ros2-exporter-agent/pull/35) is merged and promoted.

## Changes

- `setup-robcos-device.sh`
  - `ros2-exporter-agent`: `latest/edge` -> `latest/candidate`
  - `rob-cos-grafana-agent`: `core24/edge` -> `core24/candidate`

## Why

The CI/install issue tracked in [#15](https://github.com/canonical/rob-cos-device-setup/pull/15) was tied to exporter startup gating behavior. The corresponding fix is in [canonical/ros2-exporter-agent#35](https://github.com/canonical/ros2-exporter-agent/pull/35). This PR pins device setup to the candidate channel expected to contain that fix after merge/promotion.

## Notes

- This PR intentionally does **not** carry over the temporary debug additions from [#15](https://github.com/canonical/rob-cos-device-setup/pull/15) (`journalctl`/extra logs in workflow).
- Functional intent remains aligned with [#15](https://github.com/canonical/rob-cos-device-setup/pull/15): consume a fixed ros2-exporter-agent build via channel update.

