### PR TITLE
fix(ci): give enough time to everything to settle

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -121,6 +121,7 @@ jobs:
             "snap.rob-cos-grafana-agent.grafana-agent.service|enabled|active"
           )
 
+          sleep 30 # Give enough tim to everything to settle
           for unit_spec in "${expected_units[@]}"; do
             IFS='|' read -r unit_name expected_enabled expected_active <<<"${unit_spec}"
             is_service_enabled "${unit_name}" "${expected_enabled}"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -121,7 +121,7 @@ jobs:
             "snap.rob-cos-grafana-agent.grafana-agent.service|enabled|active"
           )
 
-          sleep 30 # Give enough tim to everything to settle
+          sleep 30 # Give enough time to everything to settle
           for unit_spec in "${expected_units[@]}"; do
             IFS='|' read -r unit_name expected_enabled expected_active <<<"${unit_spec}"
             is_service_enabled "${unit_name}" "${expected_enabled}"


### PR DESCRIPTION
Fix the CI.

After installing, the snap takes some time to have all its service running.

A 30 seconds timer appear to be enough.