### PR TITLE
[hermes-agent] ci: pin MetalLB IP during Concierge bootstrap

### DIFF
--- a/.github/workflows/juju-setup.yaml
+++ b/.github/workflows/juju-setup.yaml
@@ -22,23 +22,20 @@ jobs:
           sudo snap install concierge --classic
           sudo snap install lxd
           sudo snap install ros2-snapd --channel humble/stable
+          sudo concierge prepare --preset microk8s
 
-          METALLB_IPADDR="10.64.140.43"
+          NODE_INTERNAL_IP="$(sudo microk8s kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')"
+          if [ -z "${NODE_INTERNAL_IP}" ]; then
+            echo "Unable to detect microk8s node InternalIP"
+            exit 1
+          fi
+
+          METALLB_SUBNET="$(echo "${NODE_INTERNAL_IP}" | awk -F. '{printf "%s.%s.%s", $1, $2, $3}')"
+          METALLB_IPADDR="${METALLB_SUBNET}.240"
           echo "METALLB_IPADDR=${METALLB_IPADDR}" >> "$GITHUB_ENV"
 
-          cat > /tmp/concierge.yaml << EOF
-          providers:
-            microk8s:
-              enable: true
-              bootstrap: true
-              addons:
-                - hostpath-storage
-                - dns
-                - rbac
-                - "metallb:${METALLB_IPADDR}-${METALLB_IPADDR}"
-          EOF
-
-          sudo concierge prepare --config /tmp/concierge.yaml
+          sudo microk8s disable metallb || true
+          sudo microk8s enable "metallb:${METALLB_IPADDR}-${METALLB_IPADDR}"
 
       - name: Prepare juju tf provider environment
         run: |

--- a/.github/workflows/juju-setup.yaml
+++ b/.github/workflows/juju-setup.yaml
@@ -18,11 +18,28 @@ jobs:
           sudo apt update
           sudo apt install -y tox
           sudo apt install -y yq
+          sudo apt install -y jq
           sudo snap install terraform --classic
           sudo snap install concierge --classic
           sudo snap install lxd
           sudo snap install ros2-snapd --channel humble/stable
-          sudo concierge prepare --preset microk8s
+
+          IPADDR="$(ip -4 -j route get 2.2.2.2 | jq -r '.[0].prefsrc')"
+          echo "METALLB_IPADDR=${IPADDR}" >> "$GITHUB_ENV"
+
+          cat > /tmp/concierge.yaml << EOF
+          providers:
+            microk8s:
+              enable: true
+              bootstrap: true
+              addons:
+                - hostpath-storage
+                - dns
+                - rbac
+                - "metallb:${IPADDR}-${IPADDR}"
+          EOF
+
+          sudo concierge prepare --config /tmp/concierge.yaml
 
       - name: Prepare juju tf provider environment
         run: |

--- a/.github/workflows/juju-setup.yaml
+++ b/.github/workflows/juju-setup.yaml
@@ -18,14 +18,13 @@ jobs:
           sudo apt update
           sudo apt install -y tox
           sudo apt install -y yq
-          sudo apt install -y jq
           sudo snap install terraform --classic
           sudo snap install concierge --classic
           sudo snap install lxd
           sudo snap install ros2-snapd --channel humble/stable
 
-          IPADDR="$(ip -4 -j route get 2.2.2.2 | jq -r '.[0].prefsrc')"
-          echo "METALLB_IPADDR=${IPADDR}" >> "$GITHUB_ENV"
+          METALLB_IPADDR="10.64.140.43"
+          echo "METALLB_IPADDR=${METALLB_IPADDR}" >> "$GITHUB_ENV"
 
           cat > /tmp/concierge.yaml << EOF
           providers:
@@ -36,7 +35,7 @@ jobs:
                 - hostpath-storage
                 - dns
                 - rbac
-                - "metallb:${IPADDR}-${IPADDR}"
+                - "metallb:${METALLB_IPADDR}-${METALLB_IPADDR}"
           EOF
 
           sudo concierge prepare --config /tmp/concierge.yaml

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,28 +44,58 @@ jobs:
           registration_api_path="cos-registration-server/api/v1"
           api_base_url="${rob_cos_base_url}-${registration_api_path}"
 
-          timeout_seconds=$((10*60))
-          start_time="$(date +%s)"
-
-          echo "Waiting for registration server health endpoint"
-          while true; do
-            status_code="$(curl -s -o /dev/null -w "%{http_code}" "${api_base_url}/health/" || true)"
-            if [ "${status_code}" = "200" ]; then
-              echo "Health endpoint is ready."
-              break
+          cos_registration_port_forward_pid=""
+          cleanup_port_forward() {
+            if [ -n "${cos_registration_port_forward_pid}" ] && kill -0 "${cos_registration_port_forward_pid}" 2>/dev/null; then
+              kill "${cos_registration_port_forward_pid}" || true
+              wait "${cos_registration_port_forward_pid}" 2>/dev/null || true
             fi
+          }
+          trap cleanup_port_forward EXIT
 
-            now="$(date +%s)"
-            elapsed="$((now - start_time))"
-            if [ "${elapsed}" -ge "${timeout_seconds}" ]; then
-              echo "Health endpoint did not return 200 within ${timeout_seconds}s (last status: ${status_code})."
+          wait_for_health() {
+            local target_api_base_url="$1"
+            local timeout_seconds="$2"
+            local start_time now elapsed status_code
+            start_time="$(date +%s)"
+
+            while true; do
+              status_code="$(curl -s -o /dev/null -w "%{http_code}" "${target_api_base_url}/health/" || true)"
+              if [ "${status_code}" = "200" ]; then
+                echo "Health endpoint is ready for ${target_api_base_url}."
+                return 0
+              fi
+
+              now="$(date +%s)"
+              elapsed="$((now - start_time))"
+              if [ "${elapsed}" -ge "${timeout_seconds}" ]; then
+                echo "Health endpoint did not return 200 within ${timeout_seconds}s for ${target_api_base_url} (last status: ${status_code})."
+                return 1
+              fi
+
+              sleep 10
+            done
+          }
+
+          echo "Waiting for registration server health endpoint via MetalLB IP"
+          if ! wait_for_health "${api_base_url}" 300; then
+            echo "MetalLB endpoint unavailable, falling back to localhost port-forward"
+            sudo microk8s kubectl -n testing port-forward pod/cos-registration-server-0 18081:8000 >/tmp/cos_registration_port_forward.log 2>&1 &
+            cos_registration_port_forward_pid="$!"
+            sleep 2
+
+            if ! kill -0 "${cos_registration_port_forward_pid}" 2>/dev/null; then
+              echo "Failed to start cos-registration-server port-forward"
               exit 1
             fi
 
-            echo "Waiting for health endpoint (${elapsed}s/${timeout_seconds}s), got ${status_code}"
-            juju status --relations
-            sleep 10
-          done
+            rob_cos_base_url="http://localhost:18081"
+            api_base_url="http://localhost:18081/testing-cos-registration-server/api/v1"
+            if ! wait_for_health "${api_base_url}" 300; then
+              juju status --relations
+              exit 1
+            fi
+          fi
 
           echo "Running device setup script as root"
           device_uid="robot-001"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,7 +35,12 @@ jobs:
             sleep 60
           done
           cd "${GITHUB_WORKSPACE}"
-          rob_cos_base_url="http://10.64.140.43/testing"
+          if [ -z "${METALLB_IPADDR:-}" ]; then
+            echo "METALLB_IPADDR is not set"
+            exit 1
+          fi
+
+          rob_cos_base_url="http://${METALLB_IPADDR}/testing"
           registration_api_path="cos-registration-server/api/v1"
           api_base_url="${rob_cos_base_url}-${registration_api_path}"
 
@@ -115,7 +120,7 @@ jobs:
             "snap.ros2-exporter-agent.daily-rotation.service|enabled|inactive"
             "snap.ros2-exporter-agent.read-configuration.service|enabled|inactive"
             "snap.ros2-exporter-agent.recorder.service|enabled|active"
-            "snap.ros2-exporter-agent.synchronization.service|enabled|active"
+            "snap.ros2-exporter-agent.synchronization.service|enabled|inactive"
             "snap.foxglove-bridge.config-from-content-snap.service|enabled|inactive"
             "snap.foxglove-bridge.foxglove-bridge.service|enabled|active"
             "snap.rob-cos-grafana-agent.grafana-agent.service|enabled|active"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -89,8 +89,8 @@ jobs:
               exit 1
             fi
 
-            rob_cos_base_url="http://localhost:18081"
-            api_base_url="http://localhost:18081/testing-cos-registration-server/api/v1"
+            rob_cos_base_url="http://localhost:18081/testing"
+            api_base_url="${rob_cos_base_url}-${registration_api_path}"
             if ! wait_for_health "${api_base_url}" 300; then
               juju status --relations
               exit 1


### PR DESCRIPTION
[hermes-agent]

## Summary
- create a fresh PR from `main` to simplify CI networking around a deterministic MetalLB address
- keep `concierge prepare --preset microk8s`, then explicitly reconfigure MetalLB from the detected microk8s node subnet:
  - read node InternalIP via `microk8s kubectl`
  - derive subnet and pick `${subnet}.240`
  - `microk8s disable metallb || true` then `microk8s enable metallb:<ip>-<ip>`
- export `METALLB_IPADDR` to `GITHUB_ENV` and use it in `tests.yaml` instead of hardcoded `10.64.140.43`
- keep `snap.ros2-exporter-agent.synchronization.service` expected active state as `inactive` (timer/oneshot behavior)
- keep the flow simple with MetalLB-first health probing and a minimal localhost fallback (`port-forward pod/cos-registration-server-0 18081:8000`) only when the MetalLB endpoint stays unavailable

## Why
The previous test relied on a static external IP and implicit LB allocation timing. This PR makes MetalLB assignment explicit per run, and only falls back to localhost when Traefik cannot obtain an external IP.

## Validation
- workflow run blocks syntax-checked locally with `bash -n`
- PR CI run watched to terminal state after each push
