### PR TITLE
[hermes-agent] ci: use Concierge config pattern for MetalLB

### DIFF
--- a/.github/workflows/juju-setup.yaml
+++ b/.github/workflows/juju-setup.yaml
@@ -18,11 +18,33 @@ jobs:
           sudo apt update
           sudo apt install -y tox
           sudo apt install -y yq
-          sudo snap install terraform --classic
+          sudo apt install -y jq
           sudo snap install concierge --classic
+
+          IPADDR=$(ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc')
+          cat > /tmp/concierge.yaml << EOF
+          juju:
+            model-defaults:
+              logging-config: '<root>=INFO; unit=DEBUG'
+          providers:
+            microk8s:
+              enable: true
+              bootstrap: true
+              addons:
+                - hostpath-storage
+                - dns
+                - rbac
+                - "metallb:${IPADDR}-${IPADDR}"
+          EOF
+
+          echo "METALLB_IPADDR=${IPADDR}" >> "$GITHUB_ENV"
+
+          sudo concierge prepare \
+            --config /tmp/concierge.yaml \
+            --extra-snaps terraform
+
           sudo snap install lxd
           sudo snap install ros2-snapd --channel humble/stable
-          sudo concierge prepare --preset microk8s
 
       - name: Prepare juju tf provider environment
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,7 +35,12 @@ jobs:
             sleep 60
           done
           cd "${GITHUB_WORKSPACE}"
-          rob_cos_base_url="http://10.64.140.43/testing"
+          if [ -z "${METALLB_IPADDR:-}" ]; then
+            echo "METALLB_IPADDR is not set"
+            exit 1
+          fi
+
+          rob_cos_base_url="http://${METALLB_IPADDR}/testing"
           registration_api_path="cos-registration-server/api/v1"
           api_base_url="${rob_cos_base_url}-${registration_api_path}"
 


### PR DESCRIPTION
[hermes-agent]

## Summary
- create a fresh PR from `main` that uses the Concierge **config-file** pattern for microk8s bootstrap
- replace `concierge prepare --preset microk8s` with `concierge prepare --config /tmp/concierge.yaml`
- set MetalLB using the same pattern as the reference action: `metallb:${IPADDR}-${IPADDR}` where `IPADDR` is from `ip -4 -j route get 2.2.2.2`
- export `METALLB_IPADDR` and use it in tests instead of a hardcoded IP

## Scope
- only workflow wiring for Concierge config + MetalLB IP propagation
- no extra fallback logic added

## Test Plan
- let GitHub Actions `Tests` workflow run on this PR
