### PR TITLE
[hermes-agent] ci: mirror reference MicroK8s setup

### DIFF
--- a/.github/workflows/juju-setup.yaml
+++ b/.github/workflows/juju-setup.yaml
@@ -6,36 +6,82 @@ on:
       command:
         required: true
         type: string
-      runner:
-        type: string
-        default: ubuntu-latest
 
 jobs:
   setup-and-run:
-    runs-on: ${{ inputs.runner }}
+    runs-on: self-hosted-linux-amd64-noble-xlarge
     steps:
       - uses: actions/checkout@v7
 
       - name: Install dependencies
         run: |
-          sudo apt update
-          sudo apt install -y tox
-          sudo apt install -y yq
+          sudo apt-get update
+          sudo apt-get install -y tox yq
+          sudo snap install juju --classic --channel=3.6/stable
           sudo snap install terraform --classic
-          sudo snap install concierge --classic
-          sudo snap install lxd
           sudo snap install ros2-snapd --channel humble/stable
-          sudo concierge prepare --preset microk8s
 
-          IPADDR="$(ip -4 -j route get 2.2.2.2 | jq -r '.[0].prefsrc')"
-          if [ -z "${IPADDR}" ] || [ "${IPADDR}" = "null" ]; then
+      - name: Configure microk8s Docker Hub mirror
+        timeout-minutes: 10
+        run: |
+          sudo snap install microk8s --channel "1.34-strict/stable" --classic
+          sudo adduser "$USER" snap_microk8s
+
+          # Wait for microk8s to populate iptables
+          # https://chat.canonical.com/canonical/pl/jo5cg6wqjjrudqd5ybj6hhttee
+          until sudo iptables --list | grep -q -i "microk8s"
+          do
+            echo "MicroK8s has not yet configured iptables."
+            sleep 10
+          done
+
+          sudo tee /var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml << EOF
+          server = "$DOCKERHUB_MIRROR"
+          [host."${DOCKERHUB_MIRROR#'https://'}"]
+          capabilities = ["pull", "resolve"]
+          EOF
+          sudo microk8s stop
+          sudo microk8s start
+
+      - name: Set up microk8s
+        timeout-minutes: 15
+        run: |
+          sudo apt-get update
+          sudo apt-get install retry -y
+
+          # `newgrp` does not work in GitHub Actions; use `sudo --user` instead
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- microk8s status --wait-ready
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- retry --times 3 --delay 5 -- sudo microk8s enable dns
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- microk8s status --wait-ready
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- microk8s.kubectl rollout status --namespace kube-system --watch --timeout=5m deployments/coredns
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- retry --times 3 --delay 5 -- sudo microk8s enable hostpath-storage
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- microk8s.kubectl rollout status --namespace kube-system --watch --timeout=5m deployments/hostpath-provisioner
+
+          IPADDR=$(ip -4 -j route get 2.2.2.2 | sed -n -e 's/^.*prefsrc\":"\([^ "]*\).*/\1/p')
+          if [ -z "${IPADDR}" ]; then
             echo "Unable to determine the runner IP address"
             exit 1
           fi
-
           echo "METALLB_IPADDR=${IPADDR}" >> "$GITHUB_ENV"
-          sudo microk8s disable metallb || true
-          sudo microk8s enable "metallb:${IPADDR}-${IPADDR}"
+
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- retry --times 3 --delay 5 -- sudo microk8s enable "metallb:$IPADDR-$IPADDR"
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- microk8s status --wait-ready
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- retry --times 3 --delay 5 -- sudo microk8s enable ingress
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- microk8s status --wait-ready
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- retry --times 3 --delay 5 -- sudo microk8s enable rbac
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- microk8s status --wait-ready
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- retry --times 3 --delay 5 -- sudo microk8s enable registry
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- microk8s status --wait-ready
+
+          mkdir ~/.kube/
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- microk8s config | sudo tee ~/.kube/config > /dev/null
+
+      - name: Set up environment
+        timeout-minutes: 15
+        run: |
+          mkdir -p ~/.local/share/juju  # Workaround for juju 3 strict snap
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- juju bootstrap microk8s --config model-logs-size=10G microk8s
+          juju model-defaults logging-config='<root>=INFO; unit=DEBUG'
 
       - name: Prepare juju tf provider environment
         run: |

--- a/.github/workflows/juju-setup.yaml
+++ b/.github/workflows/juju-setup.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   setup-and-run:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-linux-amd64-noble-xlarge
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/juju-setup.yaml
+++ b/.github/workflows/juju-setup.yaml
@@ -6,10 +6,13 @@ on:
       command:
         required: true
         type: string
+      runner:
+        type: string
+        default: ubuntu-latest
 
 jobs:
   setup-and-run:
-    runs-on: self-hosted-linux-amd64-noble-2xlarge
+    runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@v7
 
@@ -23,6 +26,16 @@ jobs:
           sudo snap install lxd
           sudo snap install ros2-snapd --channel humble/stable
           sudo concierge prepare --preset microk8s
+
+          IPADDR="$(ip -4 -j route get 2.2.2.2 | jq -r '.[0].prefsrc')"
+          if [ -z "${IPADDR}" ] || [ "${IPADDR}" = "null" ]; then
+            echo "Unable to determine the runner IP address"
+            exit 1
+          fi
+
+          echo "METALLB_IPADDR=${IPADDR}" >> "$GITHUB_ENV"
+          sudo microk8s disable metallb || true
+          sudo microk8s enable "metallb:${IPADDR}-${IPADDR}"
 
       - name: Prepare juju tf provider environment
         run: |

--- a/.github/workflows/juju-setup.yaml
+++ b/.github/workflows/juju-setup.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   setup-and-run:
-    runs-on: self-hosted-linux-amd64-noble-xlarge
+    runs-on: self-hosted-linux-amd64-noble-2xlarge
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,6 +13,7 @@ jobs:
   tests:
     uses: ./.github/workflows/juju-setup.yaml
     with:
+      runner: self-hosted-linux-amd64-noble-xlarge
       command: |
           set -euo pipefail
           echo "Starting COS device setup workflow"
@@ -35,7 +36,42 @@ jobs:
             sleep 60
           done
           cd "${GITHUB_WORKSPACE}"
-          rob_cos_base_url="http://10.64.140.43/testing"
+
+          if [ -z "${METALLB_IPADDR:-}" ]; then
+            echo "METALLB_IPADDR is not set"
+            exit 1
+          fi
+
+          load_balancer_timeout_seconds=$((5*60))
+          load_balancer_start_time="$(date +%s)"
+
+          echo "Waiting for Traefik to obtain a load-balancer IP"
+          while true; do
+            load_balancer_ip="$(sudo microk8s kubectl -n testing get svc traefik-lb -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)"
+            if [ -n "${load_balancer_ip}" ]; then
+              echo "Traefik load-balancer IP is ${load_balancer_ip}"
+              break
+            fi
+
+            now="$(date +%s)"
+            elapsed="$((now - load_balancer_start_time))"
+            if [ "${elapsed}" -ge "${load_balancer_timeout_seconds}" ]; then
+              echo "Traefik did not obtain a load-balancer IP within ${load_balancer_timeout_seconds}s."
+              sudo microk8s kubectl -n testing get svc traefik-lb -o yaml || true
+              juju status --relations
+              exit 1
+            fi
+
+            echo "Waiting for Traefik load-balancer IP (${elapsed}s/${load_balancer_timeout_seconds}s)"
+            sleep 10
+          done
+
+          if [ "${load_balancer_ip}" != "${METALLB_IPADDR}" ]; then
+            echo "Unexpected Traefik load-balancer IP: expected ${METALLB_IPADDR}, got ${load_balancer_ip}"
+            exit 1
+          fi
+
+          rob_cos_base_url="http://${load_balancer_ip}/testing"
           registration_api_path="cos-registration-server/api/v1"
           api_base_url="${rob_cos_base_url}-${registration_api_path}"
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,6 @@ jobs:
   tests:
     uses: ./.github/workflows/juju-setup.yaml
     with:
-      runner: self-hosted-linux-amd64-noble-xlarge
       command: |
           set -euo pipefail
           echo "Starting COS device setup workflow"
@@ -56,9 +55,11 @@ jobs:
             now="$(date +%s)"
             elapsed="$((now - load_balancer_start_time))"
             if [ "${elapsed}" -ge "${load_balancer_timeout_seconds}" ]; then
-              echo "Traefik did not obtain a load-balancer IP within ${load_balancer_timeout_seconds}s."
+              message="Traefik did not obtain a load-balancer IP within ${load_balancer_timeout_seconds}s; Traefik load balancer is unable to obtain an IP or hostname from the cluster."
+              echo "::error title=Load-balancer readiness failed::${message}"
+              echo "${message}" >> "${GITHUB_STEP_SUMMARY}"
               sudo microk8s kubectl -n testing get svc traefik-lb -o yaml || true
-              juju status --relations
+              juju status --relations || true
               exit 1
             fi
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,7 +42,7 @@ jobs:
             exit 1
           fi
 
-          load_balancer_timeout_seconds=$((5*60))
+          load_balancer_timeout_seconds=$((60*60))
           load_balancer_start_time="$(date +%s)"
 
           echo "Waiting for Traefik to obtain a load-balancer IP"


### PR DESCRIPTION
[hermes-agent]

## Summary
- hardcode `self-hosted-linux-amd64-noble-xlarge` in the reusable Juju setup workflow
- replace Concierge preparation with the self-hosted MicroK8s sequence from `canonical/observability-stack` commit `e459978e88500b813b7a05d965f9e75788f38f85`
- pin Juju to `3.6/stable` and MicroK8s to `1.34-strict/stable`
- configure the runner-provided Docker Hub mirror before restarting MicroK8s
- enable DNS, hostpath storage, MetalLB, ingress, RBAC, and the registry with bounded retries and readiness checks
- explicitly bootstrap Juju after MicroK8s preparation
- retain the 1-hour Traefik load-balancer readiness window and add an actionable GitHub error annotation on failure

## Why this could solve the issue
Stage 2 proved that changing the runner and reconfiguring MetalLB after Concierge was insufficient: MetalLB appeared enabled, but Traefik never received an address. The reference workflow prepares the complete self-hosted environment in a controlled order rather than relying on Concierge defaults. Reproducing that sequence removes differences in MicroK8s channel, mirror configuration, addon ordering, rollout readiness, and Juju bootstrap.

## Scope
The reference workflow's product-specific tools, scenario matrix, and MicroCeph setup are intentionally excluded because this repository does not use them. The self-hosted runner is fixed directly rather than exposed as an input.

## Validation
- `git diff --check`
- YAML parse of both changed workflows
- `bash -n` on every multiline shell block
- independent reference-parity review
- GitHub Actions `Tests` workflow watched to terminal state after push
