### PR TITLE
[hermes-agent] ci: force runner to ubuntu-24.04

### DIFF
--- a/.github/workflows/juju-setup.yaml
+++ b/.github/workflows/juju-setup.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   setup-and-run:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
[hermes-agent]

## Summary
- Force `.github/workflows/juju-setup.yaml` to run on `ubuntu-24.04`
- Stop relying on `ubuntu-latest`, which can move to Ubuntu 26.04
- Keep CI/deployment behavior stable for current deployment constraints

## Testing
- [ ] GitHub Actions checks pass on the PR
