### PR TITLE
[hermes-agent] ci: patch MetalLB RBAC in MicroK8s

### DIFF
--- a/.github/workflows/juju-setup.yaml
+++ b/.github/workflows/juju-setup.yaml
@@ -24,6 +24,34 @@ jobs:
           sudo snap install ros2-snapd --channel humble/stable
           sudo concierge prepare --preset microk8s
 
+      - name: Patch MetalLB RBAC (microk8s-core-addons RBAC/version-skew workaround)
+        # The microk8s metallb addon's bundled RBAC is generated from an older
+        # upstream MetalLB manifest than the image tag it deploys, so both the
+        # controller and speaker ClusterRoles are missing permissions on newer
+        # CRDs (configurationstates, servicebgpstatuses). Without this, the
+        # controller cannot assign IPs (missing configurationstates informer)
+        # and the speaker CrashLoopBackOffs via cache-sync timeout. Remove
+        # once fixed upstream:
+        # https://github.com/canonical/microk8s-core-addons/issues/405
+        run: |
+          # Patch controller ClusterRole — needs configurationstates to start
+          # its informer cache and assign IPs to LoadBalancer Services
+          kubectl patch clusterrole metallb-system:controller --type=json -p='[
+            {"op":"add","path":"/rules/-","value":{"apiGroups":["metallb.io"],"resources":["configurationstates"],"verbs":["create","delete","get","list","patch","update","watch"]}},
+            {"op":"add","path":"/rules/-","value":{"apiGroups":["metallb.io"],"resources":["configurationstates/status"],"verbs":["get","patch","update"]}}
+          ]'
+          # Patch speaker ClusterRole — needs configurationstates and
+          # servicebgpstatuses to sync its cache on startup
+          kubectl patch clusterrole metallb-system:speaker --type=json -p='[
+            {"op":"add","path":"/rules/-","value":{"apiGroups":["metallb.io"],"resources":["configurationstates","configurationstates/status"],"verbs":["*"]}},
+            {"op":"add","path":"/rules/-","value":{"apiGroups":["metallb.io"],"resources":["servicebgpstatuses"],"verbs":["get","list","watch"]}}
+          ]'
+          # Restart both components so they pick up the new permissions
+          kubectl rollout restart deployment/controller -n metallb-system
+          kubectl rollout restart daemonset/speaker -n metallb-system
+          kubectl rollout status deployment/controller -n metallb-system --timeout=90s
+          kubectl rollout status daemonset/speaker -n metallb-system --timeout=90s
+
       - name: Prepare juju tf provider environment
         run: |
           CONTROLLER=$(juju whoami | yq .Controller)


### PR DESCRIPTION
[hermes-agent]

## Summary

- apply the MetalLB RBAC workaround used in [canonical/observability#475](https://github.com/canonical/observability/pull/475)
- grant the controller and speaker access to the newer `configurationstates` and `servicebgpstatuses` resources
- restart both MetalLB components after updating their ClusterRoles

This is a temporary workaround for [canonical/microk8s-core-addons#405](https://github.com/canonical/microk8s-core-addons/issues/405) and can be removed after the bundled MetalLB RBAC is fixed upstream.

## Validation

- `git diff --check`
- parsed `.github/workflows/juju-setup.yaml` with PyYAML
